### PR TITLE
🔒 Fix Timing Attack and Remove Plaintext Password Matching

### DIFF
--- a/server/database.py
+++ b/server/database.py
@@ -1,4 +1,3 @@
-import hmac
 import os
 import sqlite3
 import threading
@@ -161,37 +160,28 @@ class Database:
         self._ensure_open()
         with self.lock:
             cursor = self.conn.cursor()
-            cursor.execute('SELECT id, username, password FROM users WHERE password IS NOT NULL')
+            cursor.execute("SELECT id, username, password FROM users WHERE password IS NOT NULL")
             users = cursor.fetchall()
-        
-        for user_id, username, hashed_password in users:
-            if self._matches_password(user_id, password, hashed_password):
-                return (user_id, username)
-        return None
 
-    def _matches_password(self, user_id, password, stored_password):
+        password_bytes = str(password or "").encode("utf-8")
+        matched_user = None
+        for user_id, username, hashed_password in users:
+            if self._matches_password(password_bytes, hashed_password):
+                matched_user = (user_id, username)
+
+        return matched_user
+
+    def _matches_password(self, password_bytes, stored_password):
         if not stored_password:
             return False
 
-        password = str(password or "")
         if stored_password.startswith(("$2a$", "$2b$", "$2y$")):
             try:
-                return bcrypt.checkpw(password.encode("utf-8"), stored_password.encode("utf-8"))
+                return bcrypt.checkpw(password_bytes, stored_password.encode("utf-8"))
             except ValueError:
                 return False
 
-        if hmac.compare_digest(password, stored_password):
-            self._upgrade_plaintext_password(user_id, password)
-            return True
         return False
-
-    def _upgrade_plaintext_password(self, user_id, password):
-        hashed_password = bcrypt.hashpw(password.encode("utf-8"), bcrypt.gensalt()).decode("utf-8")
-        with self.lock:
-            cursor = self.conn.cursor()
-            cursor.execute("UPDATE users SET password = ? WHERE id = ?", (hashed_password, user_id))
-            self.conn.commit()
-            self._secure_file_permissions()
 
     def get_all_users(self):
         self._ensure_open()

--- a/server/test_alert.py
+++ b/server/test_alert.py
@@ -86,7 +86,7 @@ class TestDashboardAlert(unittest.TestCase):
 
         self.assertIsNone(self.db.verify_password("1234"))
 
-    def test_plaintext_password_is_upgraded_after_successful_match(self):
+    def test_plaintext_password_is_no_longer_supported(self):
         cursor = self.db.conn.cursor()
         cursor.execute(
             "INSERT INTO users (username, nfc_uid, password) VALUES (?, ?, ?)",
@@ -96,11 +96,7 @@ class TestDashboardAlert(unittest.TestCase):
 
         user = self.db.verify_password("1234")
 
-        self.assertIsNotNone(user)
-        cursor.execute("SELECT password FROM users WHERE username = ?", ("LegacyUser",))
-        stored_password = cursor.fetchone()[0]
-        self.assertNotEqual(stored_password, "1234")
-        self.assertTrue(stored_password.startswith(("$2a$", "$2b$", "$2y$")))
+        self.assertIsNone(user)
 
     def test_close_is_idempotent(self):
         self.db.close()


### PR DESCRIPTION
🎯 **What:** This PR fixes a timing attack vulnerability in the password verification logic and removes support for plaintext password matching.

⚠️ **Risk:** Previously, the system returned early upon finding a matching password, which could allow an attacker to infer the existence of a user or the validity of a password based on response time. Additionally, the system supported legacy plaintext passwords, which is an insecure practice.

🛡️ **Solution:**
1. Modified `verify_password` to always iterate through all users with a password, ensuring consistent timing regardless of where a match occurs.
2. Removed `hmac.compare_digest` used for plaintext matching and deleted the `_upgrade_plaintext_password` method.
3. Optimized the verification process by encoding the input password once before the comparison loop.
4. Updated the test suite to assert that plaintext passwords are no longer accepted.

---
*PR created automatically by Jules for task [12826582971424372892](https://jules.google.com/task/12826582971424372892) started by @hwkim-dev*