### PR TITLE
docs: translate core documentation to Korean

### DIFF
--- a/website/docs/appendix/ai-assisted-workflow.md
+++ b/website/docs/appendix/ai-assisted-workflow.md
@@ -2,24 +2,24 @@
 sidebar_position: 2
 ---
 
-# AI-Assisted Workflow
+# AI 지원 워크플로우 (AI-Assisted Workflow)
 
-During the development lifecycle of this experimental prototype, Large Language Models (LLMs) were utilized as engineering aids. This document outlines how AI tools were integrated into the standard development workflow.
+이 실험적 프로토타입의 개발 수명 주기(Development Lifecycle) 동안 대규모 언어 모델(LLM / Large Language Models)이 엔지니어링 보조 도구로 활용되었다. 이 문서는 AI 도구가 표준 개발 워크플로우에 어떻게 통합되었는지 간략히 설명한다.
 
-## Applications of AI Assistance
+## AI 지원의 적용 (Applications of AI Assistance)
 
-1. **Rapid Prototyping (Boilerplate Generation):**
-   AI models were used to generate standard boilerplate code, particularly for the FastAPI web server routing and the React/Docusaurus frontend configurations. This accelerated initial setup.
+1. **빠른 프로토타이핑 / 보일러플레이트 생성 (Rapid Prototyping / Boilerplate Generation):**
+   FastAPI 웹 서버 라우팅 및 React/Docusaurus 프론트엔드 구성을 위한 표준 보일러플레이트(Boilerplate) 코드를 생성하는 데 AI 모델이 사용되었다. 이를 통해 초기 설정 속도를 높였다.
 
-2. **Hardware Interfacing Guidance:**
-   LLMs provided reference implementations for the C++ MFRC522 SPI library and Keypad matrix scanning, which were subsequently refined and adapted to the specific pinout of the prototype.
+2. **하드웨어 인터페이스 지침 (Hardware Interfacing Guidance):**
+   LLM은 C++ MFRC522 SPI 라이브러리 및 Keypad 매트릭스 스캐닝을 위한 참조 구현(Reference Implementation)을 제공했으며, 이후 프로토타입의 특정 핀 아웃(Pinout)에 맞게 다듬어지고 적용되었다.
 
-3. **Documentation Structuring:**
-   AI tools assisted in formatting raw engineering notes into structured markdown documents and generating Mermaid diagram syntax based on natural language descriptions of the architecture.
+3. **문서 구조화 (Documentation Structuring):**
+   원시 엔지니어링 노트(Raw engineering notes)를 구조화된 마크다운 문서로 포맷팅하고, 아키텍처에 대한 자연어 설명을 기반으로 다이어그램 구문을 생성하는 데 AI 도구가 지원되었다.
 
-## Workflow Integration Guidelines
+## 워크플로우 통합 가이드라인 (Workflow Integration Guidelines)
 
-To maintain code quality and security, the following guidelines were strictly adhered to:
-- **Zero-Trust Review:** All AI-generated code was subjected to manual code review and local unit testing.
-- **Architectural Authority:** Core architectural decisions (e.g., synchronous vs asynchronous processing, database schema design) were made by human engineers; AI was strictly used for implementation execution.
-- **Security Primitives:** Cryptographic operations (e.g., PIN hashing via `bcrypt`) were manually verified against industry best practices rather than relying solely on AI suggestions.
+코드 품질과 보안을 유지하기 위해 다음 가이드라인을 엄격하게 준수했다.
+- **제로 트러스트 검토 (Zero-Trust Review):** AI가 생성한 모든 코드는 수동 코드 리뷰(Manual code review) 및 로컬 단위 테스트(Local unit testing)를 거쳤다.
+- **아키텍처 권한 (Architectural Authority):** 핵심 아키텍처 결정(예: 동기식 vs 비동기식 처리, 데이터베이스 스키마 설계)은 인간 엔지니어가 내렸으며, AI는 오직 구현 실행을 위해서만 엄격하게 사용되었다.
+- **보안 원시 요소 (Security Primitives):** 암호화 작업(예: `bcrypt`를 통한 PIN 해싱)은 AI의 제안에만 의존하지 않고 업계 모범 사례를 기반으로 수동으로 검증되었다.

--- a/website/docs/appendix/development-notes.md
+++ b/website/docs/appendix/development-notes.md
@@ -2,22 +2,22 @@
 sidebar_position: 1
 ---
 
-# Development Methodology
+# 개발 방법론 (Development Methodology)
 
-This appendix details the engineering methodology and iterative decisions made during the development of the 2FA prototype.
+이 부록(Appendix)에서는 2FA 프로토타입 개발 과정에서 이루어진 엔지니어링 방법론과 반복적인 의사 결정 사항들을 자세히 설명한다.
 
-## Iterative Development Phases
+## 반복적 개발 단계 (Iterative Development Phases)
 
-The project was executed in sequential phases to isolate complexity:
+이 프로젝트는 복잡성을 분리하기 위해 순차적인 단계로 실행되었다.
 
-### Phase 1: Hardware Abstraction
-Initial development focused exclusively on Arduino firmware. The goal was to abstract the MFRC522 SPI communications and Matrix Keypad polling into a simple, reliable serial interface. This allowed the backend to treat the hardware rig as a black-box I/O stream.
+### 1단계: 하드웨어 추상화 (Phase 1: Hardware Abstraction)
+초기 개발은 Arduino 펌웨어에만 독점적으로 집중했다. 목표는 MFRC522 SPI 통신 및 Matrix Keypad 폴링(Polling)을 간단하고 안정적인 시리얼 인터페이스로 추상화하는 것이었다. 이를 통해 Backend는 하드웨어 장비를 블랙박스(Black-box) I/O 스트림으로 취급할 수 있게 되었다.
 
-### Phase 2: Core Authentication Logic
-The Python backend was developed using Test-Driven Development (TDD) principles. SQLite with Write-Ahead Logging (WAL) was selected to provide concurrent read access for the dashboard without locking the primary authentication thread.
+### 2단계: 핵심 인증 로직 (Phase 2: Core Authentication Logic)
+Python Backend는 테스트 주도 개발(TDD / Test-Driven Development) 원칙을 사용하여 개발되었다. 1차 인증 스레드(Thread)를 잠그지 않고 대시보드(Dashboard)의 동시 읽기 액세스를 제공하기 위해 WAL(Write-Ahead Logging) 모드의 SQLite를 선택했다.
 
-### Phase 3: Vision Integration
-YOLOv8 was integrated for facial extraction due to its balance of speed and accuracy on standard CPU/Edge hardware. The initial implementation suffered from false positives in poorly lit environments; this was mitigated by implementing a strict confidence threshold and enforcing a minimum bounding-box size.
+### 3단계: 비전 통합 (Phase 3: Vision Integration)
+표준 CPU/Edge 하드웨어에서 속도와 정확도의 균형을 맞추기 위해 얼굴 추출 용도로 YOLOv8을 통합했다. 초기 구현에서는 조명이 어두운 환경에서 오탐(False Positive)이 발생하는 문제가 있었으나, 엄격한 신뢰도 임계값(Confidence Threshold)을 구현하고 최소 경계 상자(Bounding-box) 크기를 강제함으로써 완화했다.
 
-### Phase 4: System Integration
-The final phase connected the serial manager to the vision pipeline. The most significant challenge was managing asynchronous serial timeouts while the vision module blocked the CPU. This was resolved by decoupling the serial listener into a dedicated background thread.
+### 4단계: 시스템 통합 (Phase 4: System Integration)
+마지막 단계에서는 Serial Manager를 Vision 파이프라인에 연결했다. 가장 큰 과제는 Vision 모듈이 CPU를 차단(Block)하는 동안 비동기 시리얼 시간 초과(Asynchronous Serial Timeouts)를 관리하는 것이었다. 이는 시리얼 리스너(Serial Listener)를 전용 백그라운드 스레드로 분리(Decoupling)하여 해결했다.

--- a/website/docs/operation/user-guide.md
+++ b/website/docs/operation/user-guide.md
@@ -2,61 +2,61 @@
 sidebar_position: 2
 ---
 
-# User Guide and Operation
+# 사용자 가이드 및 운영 (User Guide and Operation)
 
-This document details the standard operating procedures and expected behavior of the 2FA Smart Door Lock System from an end-user and administrator perspective.
+이 문서는 최종 사용자와 관리자 관점에서 2FA Smart Door Lock System의 표준 운영 절차와 예상되는 동작을 자세히 설명한다.
 
-## System Startup Sequence
+## 시스템 시작 순서 (System Startup Sequence)
 
-1. **Power Initialization**: Ensure the Arduino and the independent lock power supply are energized.
-2. **Backend Initialization**: Start the Python FastAPI server (`server/main.py`). The server will automatically initialize the SQLite database if it does not exist.
-3. **Serial Handshake**: Upon startup, the Arduino broadcasts a `SYSTEM_READY` signal over the USB serial connection. The backend acknowledges this signal and begins the polling loop.
-4. **Vision Module Warm-up**: The YOLOv8 model is loaded into memory. The system is fully operational once the backend logs indicate the camera feed is successfully captured.
+1. **전원 초기화 (Power Initialization)**: Arduino와 독립된 잠금장치 전원 공급 장치에 전원이 켜져 있는지 확인한다.
+2. **백엔드 초기화 (Backend Initialization)**: Python FastAPI 서버(`server/main.py`)를 시작한다. 서버는 SQLite 데이터베이스가 없는 경우 자동으로 초기화한다.
+3. **시리얼 핸드셰이크 (Serial Handshake)**: 시작 시 Arduino는 USB 시리얼 연결을 통해 `SYSTEM_READY` 신호를 브로드캐스트(Broadcast)한다. Backend는 이 신호를 확인하고 폴링 루프(Polling Loop)를 시작한다.
+4. **비전 모듈 준비 (Vision Module Warm-up)**: YOLOv8 모델이 메모리에 로드된다. Backend 로그에 카메라 화면이 성공적으로 캡처되었다고 표시되면 시스템이 완전히 작동하는 것이다.
 
-## Authentication Flow (End-User)
+## 인증 흐름 (최종 사용자) (Authentication Flow / End-User)
 
-To gain access, a registered user must successfully complete the two-factor authentication pipeline.
+접근 권한을 얻으려면 등록된 사용자가 2FA 파이프라인을 성공적으로 완료해야 한다.
 
-### Step 1: Primary Authentication (NFC or PIN)
-The user initiates the process by presenting a registered credential to the localized hardware.
-- **NFC Method**: Tap a registered 13.56MHz card against the MFRC522 reader.
-- **PIN Method**: Input a registered 4-digit code using the matrix keypad, followed by the specific termination key (e.g., `#` or `A`, depending on configuration).
+### 1단계: 1차 인증 (NFC 또는 PIN) (Step 1: Primary Authentication)
+사용자는 등록된 자격 증명을 로컬 하드웨어에 제시하여 프로세스를 시작한다.
+- **NFC 방식**: 등록된 13.56MHz 카드를 MFRC522 리더에 탭(Tap)한다.
+- **PIN 방식**: 매트릭스 키패드를 사용하여 등록된 4자리 코드를 입력한 후, 특정 종료 키(예: 구성에 따라 `#` 또는 `A`)를 누른다.
 
-*If the primary credential is valid, the system immediately proceeds to Step 2.*
+*1차 자격 증명이 유효하면 시스템은 즉시 2단계로 넘어간다.*
 
-### Step 2: Secondary Authentication (Facial Verification)
-Upon primary success, the backend activates the vision module.
-- The user must stand within the camera's field of view.
-- The system captures a frame, extracts facial embeddings via YOLOv8, and compares them against the stored profile associated with the primary credential.
+### 2단계: 2차 인증 (얼굴 인식) (Step 2: Secondary Authentication)
+1차 인증이 성공하면 Backend는 Vision 모듈을 활성화한다.
+- 사용자는 카메라의 시야각(Field of View) 안에 서 있어야 한다.
+- 시스템은 프레임을 캡처하고, YOLOv8을 통해 얼굴 임베딩(Face Embeddings)을 추출하며, 1차 자격 증명과 연결된 저장된 프로필과 비교한다.
 
-### Step 3: Relay Unlock Behavior
-- If the facial verification returns a positive match, the backend transmits an explicit `UNLOCK` command via serial.
-- The Arduino toggles the relay pin, energizing the lock mechanism for a pre-configured duration (default: 3000ms), allowing physical entry.
-- The system immediately relocks after the timeout expires.
+### 3단계: 릴레이 잠금 해제 동작 (Step 3: Relay Unlock Behavior)
+- 얼굴 검증 결과가 긍정적(일치)이면, Backend는 시리얼을 통해 명시적인 `UNLOCK` 명령을 전송한다.
+- Arduino는 릴레이 핀을 토글(Toggle)하여 사전 구성된 시간(기본값: 3000ms) 동안 잠금 메커니즘에 전원을 공급하여 물리적 출입을 허용한다.
+- 시간 초과(Timeout)가 만료되면 시스템은 즉시 다시 잠긴다.
 
-## Failure Handling and Logging
+## 실패 처리 및 로깅 (Failure Handling and Logging)
 
-The system is designed to default to a secure, locked state upon any failure. All authentication attempts are immutably logged to the SQLite `access_logs` table.
+이 시스템은 어떤 실패가 발생하더라도 안전한 잠금 상태를 유지하도록 설계되었다. 모든 인증 시도는 SQLite `access_logs` 테이블에 변경할 수 없게(Immutably) 로깅된다.
 
-- **Primary Failure**: If an unregistered NFC card is tapped or an incorrect PIN is entered, the event is logged as `FAILURE_AUTH1`. The vision module is not engaged.
-- **Secondary Failure**: If the primary credential is valid but the camera detects a mismatched face, multiple faces, or no face within the timeout period, the event is logged as `FAILURE_AUTH2`. The door remains locked.
-- **Hardware Disconnect**: If the serial connection to the Arduino is severed, the backend logs a critical system error. The Arduino, lacking an `UNLOCK` command, will keep the relay disengaged.
+- **1차 실패 (Primary Failure)**: 등록되지 않은 NFC 카드가 태그되거나 잘못된 PIN이 입력되면, 해당 이벤트는 `FAILURE_AUTH1`로 기록된다. Vision 모듈은 작동하지 않는다.
+- **2차 실패 (Secondary Failure)**: 1차 자격 증명은 유효하지만 카메라가 일치하지 않는 얼굴, 여러 얼굴을 감지하거나 지정된 시간 내에 얼굴을 감지하지 못하면 이벤트는 `FAILURE_AUTH2`로 기록된다. 문은 잠긴 상태를 유지한다.
+- **하드웨어 연결 끊김 (Hardware Disconnect)**: Arduino와의 시리얼 연결이 끊어지면 Backend는 치명적인 시스템 오류를 기록한다. `UNLOCK` 명령이 없는 Arduino는 릴레이를 비활성화된 상태로 유지한다.
 
-## Dashboard Monitoring
+## 대시보드 모니터링 (Dashboard Monitoring)
 
-Administrators can monitor the system's performance and audit access logs via the web dashboard.
-- Navigate to the **Validation Status** page on the deployed Docusaurus site.
-- The dashboard provides a summary of total authentication attempts, success/failure ratios, and a distribution of failure reasons based on the static validation dataset.
+관리자는 웹 대시보드(Web Dashboard)를 통해 시스템 성능을 모니터링하고 감사 로그(Audit Logs)를 확인할 수 있다.
+- 배포된 Docusaurus 사이트의 **Validation Status** 페이지로 이동한다.
+- 대시보드는 총 인증 시도 횟수, 성공/실패 비율, 그리고 정적 검증 데이터 세트를 기반으로 한 실패 원인 분포에 대한 요약을 제공한다.
 
-## Manual Validation (Mock Mode)
+## 수동 검증 (모의 모드) (Manual Validation / Mock Mode)
 
-For development or demonstration purposes without physical hardware:
-1. Ensure the backend is running.
-2. Execute `python3 server/mock_arduino.py` in a separate terminal.
-3. Use the CLI prompts to inject simulated NFC UIDs or PIN codes.
-4. Observe the backend logs to verify the two-stage logic and the correct transmission of the simulated `UNLOCK` command.
+물리적 하드웨어가 없는 개발 또는 시연 목적의 경우:
+1. Backend가 실행 중인지 확인한다.
+2. 별도의 터미널에서 `python3 server/mock_arduino.py`를 실행한다.
+3. CLI 프롬프트를 사용하여 시뮬레이션된 NFC UID 또는 PIN 코드를 주입한다.
+4. Backend 로그를 관찰하여 2단계 검증 논리와 시뮬레이션된 `UNLOCK` 명령의 올바른 전송을 확인한다.
 
-## Known Operational Limitations
+## 알려진 운영 한계점 (Known Operational Limitations)
 
-- **Lighting Dependency**: The facial verification module utilizes standard RGB webcams and its accuracy is degraded in low-light environments.
-- **Single Node Logging**: Audit logs are stored locally on the host machine running the Python backend. Multi-door synchronization is not currently supported.
+- **조명 의존성 (Lighting Dependency)**: 얼굴 검증 모듈은 표준 RGB 웹캠을 사용하므로 저조도 환경에서는 정확도가 저하된다.
+- **단일 노드 로깅 (Single Node Logging)**: 감사 로그(Audit Logs)는 Python Backend가 실행되는 호스트 장비에 로컬로 저장된다. 현재 다중 도어(Multi-door) 동기화는 지원되지 않는다.

--- a/website/docs/security/threat-model.md
+++ b/website/docs/security/threat-model.md
@@ -2,21 +2,21 @@
 sidebar_position: 1
 ---
 
-# Threat Model
+# 위협 모델 (Threat Model)
 
-This section outlines the potential threats to the 2FA Smart Door Lock System, the expected impact, the implemented mitigations, and the remaining residual risks.
+이 섹션에서는 2FA Smart Door Lock System에 대한 잠재적인 위협, 예상되는 영향, 구현된 완화 전략, 그리고 남아있는 잔여 위험에 대해 간략히 설명한다.
 
-## Security Matrix
+## 보안 매트릭스 (Security Matrix)
 
-| Threat Actor / Action | Impact | Mitigation Strategy | Remaining Risk |
+| 위협 행위자 / 행동 (Threat Actor / Action) | 영향 (Impact) | 완화 전략 (Mitigation Strategy) | 잔여 위험 (Remaining Risk) |
 |---|---|---|---|
-| **Unauthorized User with Stolen NFC Card** | High. System attempts primary auth. | System requires positive secondary authentication (Face Match). | If the attacker also visually resembles the user (or possesses a high-quality spoofing mechanism), access may be granted. |
-| **Unauthorized User guessing PIN** | High. | Brute-force is hindered by secondary Face Match requirement. Invalid attempts are logged. | Physical damage to keypad from repeated use. |
-| **Presentation Attack (Photo/Screen Spoofing)** | Critical. Bypass of biometric factor. | YOLOv8 model thresholding prevents blurry matches. | **High.** Standard 2D RGB cameras cannot reliably detect depth or liveness. A high-resolution tablet video could bypass the system. |
-| **Serial Bus Tampering** | Critical. Injection of `UNLOCK` command. | None implemented in current software. | **High.** If the attacker accesses the USB cable between the Server and Arduino, they can send plaintext serial commands. |
-| **Physical Relay Bypass** | Critical. Direct lock actuation. | Physical enclosure (Assumed). | **High.** If the attacker shorts the relay output terminals directly, the software cannot detect or prevent it. |
-| **Power Interruption** | Moderate. Denial of service. | Use of fail-secure physical lock hardware. | Legitimate users cannot enter during a power outage unless mechanical override keys are provided. |
+| **도난당한 NFC 카드를 가진 인가되지 않은 사용자** | 높음 (High). 시스템이 1차 인증을 시도한다. | 시스템은 긍정적인 2차 인증(얼굴 일치)을 요구한다. | 공격자가 사용자와 시각적으로 유사하거나(또는 고품질의 위조 메커니즘을 보유한 경우) 접근이 허용될 수 있다. |
+| **PIN을 추측하는 인가되지 않은 사용자** | 높음 (High). | 2차 얼굴 일치 요구 사항으로 인해 무차별 대입 공격(Brute-force)이 방해받는다. 유효하지 않은 시도는 로깅된다. | 반복적인 사용으로 인한 키패드의 물리적 손상. |
+| **제시 공격 (사진/화면 위조) (Presentation Attack / Photo/Screen Spoofing)** | 치명적 (Critical). 생체 인식 요소를 우회한다. | YOLOv8 모델 임계값(Thresholding) 설정으로 흐릿한 일치를 방지한다. | **높음 (High).** 표준 2D RGB 카메라는 깊이나 활성(Liveness)을 안정적으로 감지할 수 없다. 고해상도 태블릿 비디오가 시스템을 우회할 수 있다. |
+| **시리얼 버스 변조 (Serial Bus Tampering)** | 치명적 (Critical). `UNLOCK` 명령을 주입한다. | 현재 소프트웨어에는 구현되지 않음. | **높음 (High).** 공격자가 Server와 Arduino 사이의 USB 케이블에 접근하면 일반 텍스트 시리얼 명령을 보낼 수 있다. |
+| **물리적 릴레이 우회 (Physical Relay Bypass)** | 치명적 (Critical). 잠금장치를 직접 작동시킨다. | 물리적 외함(Physical enclosure) (가정됨). | **높음 (High).** 공격자가 릴레이 출력 단자를 직접 단락(Short)시키는 경우, 소프트웨어는 이를 감지하거나 방지할 수 없다. |
+| **전원 차단 (Power Interruption)** | 보통 (Moderate). 서비스 거부(Denial of service). | Fail-secure 물리적 잠금 하드웨어 사용. | 기계적인 재정의(Override) 키가 제공되지 않는 한 정전 시 정당한 사용자가 들어갈 수 없다. |
 
-## Design Philosophy
+## 설계 철학 (Design Philosophy)
 
-The system adheres to the principle of "Fail-Secure". Software exceptions, missing hardware (e.g., camera disconnected), or communication timeouts default to a denied state. The relay remains disengaged unless a continuous, positive logic path completes successfully.
+이 시스템은 "Fail-Secure" 원칙을 고수한다. 소프트웨어 예외 발생, 하드웨어 누락(예: 카메라 연결 끊김) 또는 통신 시간 초과 시 기본적으로 거부 상태가 된다. 릴레이는 연속적이고 긍정적인 논리 경로가 성공적으로 완료되지 않는 한 비활성화된 상태를 유지한다.

--- a/website/docs/software/backend.md
+++ b/website/docs/software/backend.md
@@ -2,33 +2,33 @@
 sidebar_position: 1
 ---
 
-# Backend Architecture
+# 백엔드 아키텍처 (Backend Architecture)
 
-The backend serves as the authoritative decision-making component of the system. It processes incoming data from the Arduino, interfaces with the vision module, and maintains the database.
+백엔드(Backend)는 시스템의 권한 있는 의사 결정(Authoritative Decision-making) 컴포넌트 역할을 한다. Arduino에서 들어오는 데이터를 처리하고, Vision 모듈과 통신하며, 데이터베이스를 유지 관리한다.
 
-## Core Modules
+## 핵심 모듈 (Core Modules)
 
 1. **`main.py` / `app.py`:**
-   - Initializes the FastAPI web application.
-   - Manages API routing for web dashboards and external integrations.
+   - FastAPI 웹 애플리케이션을 초기화한다.
+   - 웹 대시보드(Web Dashboard) 및 외부 통합을 위한 API 라우팅을 관리한다.
 2. **`serial_manager.py`:**
-   - Handles asynchronous serial communication with the Arduino.
-   - Parses incoming UID/PIN strings and dispatches them to the validation logic.
-   - Provides a `mock` mode for CI/CD environments where physical hardware is absent.
+   - Arduino와의 비동기 시리얼 통신(Asynchronous Serial Communication)을 처리한다.
+   - 들어오는 UID/PIN 문자열을 구문 분석(Parsing)하여 검증 로직으로 전달한다.
+   - 물리적 하드웨어가 없는 CI/CD 환경을 위해 `mock` 모드를 제공한다.
 3. **`vision_ai.py`:**
-   - Manages the YOLOv8 and OpenCV pipeline.
-   - Captures frames from the connected camera.
-   - Extracts facial embeddings and performs cosine similarity matching against registered profiles.
+   - YOLOv8 및 OpenCV 파이프라인을 관리한다.
+   - 연결된 카메라에서 프레임을 캡처한다.
+   - 얼굴 임베딩(Facial Embeddings)을 추출하고 등록된 프로필과 코사인 유사도 매칭(Cosine Similarity Matching)을 수행한다.
 4. **`validation.py`:**
-   - Orchestrates the two-stage authentication logic.
-   - Ensures UID formatting consistency.
+   - 2단계 인증 로직을 조율(Orchestration)한다.
+   - UID 형식의 일관성을 보장한다.
 
-## API Endpoints (Web Interface)
+## API 엔드포인트 (웹 인터페이스) (API Endpoints / Web Interface)
 
-| Endpoint | Method | Purpose |
+| 엔드포인트 (Endpoint) | 메서드 (Method) | 목적 (Purpose) |
 |---|---|---|
-| `/api/logs` | GET | Retrieve a paginated list of access logs. |
-| `/api/status` | GET | Retrieve system health metrics (DB connection, Vision module status). |
-| `/api/register` | POST | Register a new user with NFC UID and initial facial scan. |
+| `/api/logs` | GET | 페이지네이션(Paginated)된 접근 로그 목록을 검색한다. |
+| `/api/status` | GET | 시스템 상태 측정 항목(DB 연결, Vision 모듈 상태)을 검색한다. |
+| `/api/register` | POST | NFC UID 및 초기 얼굴 스캔을 사용하여 새로운 사용자를 등록한다. |
 
-*Note: Administrative endpoints require separate network-level authentication, which is outside the scope of this hardware prototype documentation.*
+*참고: 관리자 엔드포인트는 별도의 네트워크 수준 인증이 필요하며, 이는 이 하드웨어 프로토타입 문서의 범위를 벗어난다.*

--- a/website/docs/software/database.md
+++ b/website/docs/software/database.md
@@ -2,32 +2,32 @@
 sidebar_position: 2
 ---
 
-# Database Schema
+# 데이터베이스 스키마 (Database Schema)
 
-The system uses an embedded SQLite database (`database.py`) to ensure local, zero-network-dependency operation. The database operates in WAL (Write-Ahead Logging) mode to support concurrent reads from the web dashboard while the authentication loop writes logs.
+이 시스템은 로컬 및 제로 네트워크 종속성(Zero-network-dependency) 작동을 보장하기 위해 내장형 SQLite 데이터베이스(`database.py`)를 사용한다. 데이터베이스는 인증 루프가 로그를 기록하는 동안 웹 대시보드(Web Dashboard)에서 동시 읽기(Concurrent Reads)를 지원하기 위해 WAL(Write-Ahead Logging) 모드로 작동한다.
 
-## Tables
+## 테이블 (Tables)
 
 ### 1. `users`
 
-Stores registered user credentials.
+등록된 사용자의 자격 증명을 저장한다.
 
-| Column | Type | Constraints | Description |
+| 열 (Column) | 타입 (Type) | 제약 조건 (Constraints) | 설명 (Description) |
 |---|---|---|---|
-| `id` | INTEGER | PRIMARY KEY | Unique internal identifier. |
-| `name` | TEXT | NOT NULL | Display name. |
-| `nfc_uid` | TEXT | UNIQUE | Normalized NFC card UID. |
-| `pin_hash` | TEXT | | Bcrypt hashed PIN code (optional). |
-| `face_encoding` | BLOB | | Serialized vector array of the user's face. |
+| `id` | INTEGER | PRIMARY KEY | 고유한 내부 식별자(Identifier). |
+| `name` | TEXT | NOT NULL | 표시 이름(Display name). |
+| `nfc_uid` | TEXT | UNIQUE | 정규화된(Normalized) NFC 카드 UID. |
+| `pin_hash` | TEXT | | Bcrypt로 해시 처리된 PIN 코드 (선택 사항). |
+| `face_encoding` | BLOB | | 사용자의 얼굴에 대한 직렬화된(Serialized) 벡터 배열. |
 
 ### 2. `access_logs`
 
-Provides an immutable audit trail of all system activity.
+모든 시스템 활동에 대한 변경 불가능한(Immutable) 감사 추적(Audit Trail)을 제공한다.
 
-| Column | Type | Constraints | Description |
+| 열 (Column) | 타입 (Type) | 제약 조건 (Constraints) | 설명 (Description) |
 |---|---|---|---|
-| `id` | INTEGER | PRIMARY KEY | Unique log entry ID. |
-| `timestamp` | DATETIME | DEFAULT CURRENT_TIMESTAMP | Time of the event. |
-| `nfc_uid` | TEXT | | The UID presented (if any). |
-| `status` | TEXT | NOT NULL | E.g., `SUCCESS`, `FAILURE_AUTH1`, `FAILURE_AUTH2`. |
-| `reason` | TEXT | | Detailed failure context (e.g., "Face Mismatch"). |
+| `id` | INTEGER | PRIMARY KEY | 고유한 로그 항목 ID. |
+| `timestamp` | DATETIME | DEFAULT CURRENT_TIMESTAMP | 이벤트 발생 시간. |
+| `nfc_uid` | TEXT | | 제시된 UID (있는 경우). |
+| `status` | TEXT | NOT NULL | 예: `SUCCESS`, `FAILURE_AUTH1`, `FAILURE_AUTH2`. |
+| `reason` | TEXT | | 상세한 실패 컨텍스트 (예: "Face Mismatch"). |

--- a/website/docs/software/serial-protocol.md
+++ b/website/docs/software/serial-protocol.md
@@ -2,25 +2,25 @@
 sidebar_position: 3
 ---
 
-# Serial Protocol
+# 시리얼 프로토콜 (Serial Protocol)
 
-Communication between the Arduino and the Backend Server utilizes a simple plaintext serial protocol over USB (9600 Baud).
+Arduino와 Backend 서버 간의 통신은 USB를 통한 간단한 일반 텍스트(Plaintext) 시리얼 프로토콜(9600 Baud)을 사용한다.
 
-## Message Formats
+## 메시지 형식 (Message Formats)
 
 ### Arduino → Server
 
-| Event | String Format | Example |
+| 이벤트 (Event) | 문자열 형식 (String Format) | 예시 (Example) |
 |---|---|---|
-| System Ready | `SYSTEM_READY` | `SYSTEM_READY` |
-| NFC Card Tap | `UID:<hex_string>` | `UID:A1B2C3D4` |
-| PIN Entry | `PIN:<string>` | `PIN:1234` |
+| 시스템 준비 (System Ready) | `SYSTEM_READY` | `SYSTEM_READY` |
+| NFC 카드 탭 (NFC Card Tap) | `UID:<hex_string>` | `UID:A1B2C3D4` |
+| PIN 입력 (PIN Entry) | `PIN:<string>` | `PIN:1234` |
 
 ### Server → Arduino
 
-| Command | Action |
+| 명령 (Command) | 동작 (Action) |
 |---|---|
-| `UNLOCK` | Instructs the Arduino to pull the relay pin HIGH/LOW for the configured unlock duration (e.g., 3000ms). |
-| `DENY` | Explicit rejection command. Triggers an error beep or LED blink (if implemented). Relay state remains locked. |
+| `UNLOCK` | 설정된 잠금 해제 시간(예: 3000ms) 동안 릴레이 핀을 HIGH/LOW로 당기도록 Arduino에 지시한다. |
+| `DENY` | 명시적인 거부 명령. 오류 비프음 또는 LED 깜박임을 트리거한다(구현된 경우). 릴레이 상태는 잠긴 상태로 유지된다. |
 
-*Security Note: This protocol is currently unencrypted. See the Security section regarding physical access limitations.*
+*보안 참고 사항: 이 프로토콜은 현재 암호화되어 있지 않다. 물리적 접근 제한에 관해서는 보안(Security) 섹션을 참조한다.*

--- a/website/docs/validation/limitations.md
+++ b/website/docs/validation/limitations.md
@@ -2,21 +2,21 @@
 sidebar_position: 2
 ---
 
-# Limitations
+# 한계점 (Limitations)
 
-The current implementation of the 2FA Smart Door Lock System is an experimental prototype. It successfully demonstrates the integration of multiple hardware sensors and computer vision logic, but it possesses several limitations that preclude its use in production environments.
+2FA Smart Door Lock System의 현재 구현은 실험적인 프로토타입이다. 다중 하드웨어 센서와 컴퓨터 비전 로직의 통합을 성공적으로 시연했지만, 실제 프로덕션 환경(Production Environment)에서 사용하기에는 여러 가지 한계가 존재한다.
 
-### 1. Cryptographic Security of Serial Links
-The communication between the Backend Server and the Microcontroller is transmitted as plaintext over USB Serial. An attacker with physical access to the cabling can trivially inject an `UNLOCK` string to bypass all software authentication. Production systems require encrypted data buses (e.g., OSDP protocol).
+### 1. 시리얼 링크의 암호화 보안 (Cryptographic Security of Serial Links)
+Backend 서버와 마이크로컨트롤러 간의 통신은 USB 시리얼을 통해 일반 텍스트(Plaintext)로 전송된다. 케이블에 물리적으로 접근할 수 있는 공격자는 `UNLOCK` 문자열을 손쉽게 주입하여 모든 소프트웨어 인증을 우회할 수 있다. 실제 프로덕션 시스템은 암호화된 데이터 버스(예: OSDP 프로토콜)를 필요로 한다.
 
-### 2. Biometric Anti-Spoofing
-The vision module utilizes standard 2D webcams. It is vulnerable to presentation attacks using high-resolution photographs or video playback. Commercial systems mitigate this utilizing depth sensors (stereo cameras, IR structured light).
+### 2. 생체 인식 위조 방지 (Biometric Anti-Spoofing)
+Vision 모듈은 표준 2D 웹캠을 사용한다. 따라서 고해상도 사진이나 비디오 재생을 이용한 제시 공격(Presentation Attack)에 취약하다. 상업용 시스템은 깊이 센서(Depth Sensor / 예: 스테레오 카메라, 적외선 구조광)를 활용하여 이를 완화한다.
 
-### 3. Relay Isolation and Physical Security
-The prototype does not enforce physical isolation of the relay. If the relay module is exposed, the lock can be actuated by manually bridging the output terminals. Robust enclosures and secure-side mounting of critical switching hardware are required.
+### 3. 릴레이 격리 및 물리적 보안 (Relay Isolation and Physical Security)
+프로토타입은 릴레이의 물리적 격리를 강제하지 않는다. 릴레이 모듈이 노출되면 출력 단자를 수동으로 연결하여 잠금장치를 작동시킬 수 있다. 중요 스위칭 하드웨어는 견고한 외함(Enclosure)에 넣고 보안 구역(Secure-side) 내부에 장착해야 한다.
 
-### 4. Limited User Administration
-Currently, user registration is handled via direct backend API calls or basic web endpoints. The system lacks a comprehensive Identity and Access Management (IAM) interface for bulk enrollment, role-based access control, or scheduled access policies.
+### 4. 제한된 사용자 관리 (Limited User Administration)
+현재 사용자 등록은 직접적인 Backend API 호출이나 기본적인 웹 엔드포인트를 통해 처리된다. 시스템에는 대량 등록(Bulk Enrollment), 역할 기반 접근 제어(Role-based Access Control), 또는 예약된 접근 정책(Scheduled Access Policies)을 위한 포괄적인 계정 및 접근 관리(IAM / Identity and Access Management) 인터페이스가 부족하다.
 
-### 5. Single Node Architecture
-The SQLite database and vision processing occur on a single local node. There is no synchronization with a centralized server, meaning multi-door deployments would operate as entirely independent silos.
+### 5. 단일 노드 아키텍처 (Single Node Architecture)
+SQLite 데이터베이스 및 Vision 처리는 단일 로컬 노드에서 발생한다. 중앙 집중식 서버와의 동기화가 없으므로 여러 문에 배포할 경우 완전히 독립된 사일로(Silo)로 작동하게 된다.

--- a/website/docs/validation/test-plan.md
+++ b/website/docs/validation/test-plan.md
@@ -2,33 +2,33 @@
 sidebar_position: 1
 ---
 
-# Test Plan and Results
+# 테스트 계획 및 결과 (Test Plan and Results)
 
-This document outlines the standard validation procedures used to confirm the functional correctness of the 2FA Smart Door Lock System.
+이 문서는 2FA Smart Door Lock System의 기능적 정확성을 확인하기 위해 사용된 표준 검증 절차를 간략히 설명한다.
 
-## Unit Testing
+## 단위 테스트 (Unit Testing)
 
-The Python backend utilizes the standard `unittest` framework to verify individual component logic. Tests can be executed locally via:
+Python Backend는 개별 컴포넌트의 로직을 검증하기 위해 표준 `unittest` 프레임워크를 사용한다. 다음 명령어를 통해 로컬에서 테스트를 실행할 수 있다.
 
 ```bash
 python3 -B -m unittest discover -s server -p 'test*.py'
 ```
 
-Key unit test coverage includes:
-- `test_validation.py`: Verifies UID normalization and PIN hashing.
-- `test_database*.py`: Verifies concurrent write safety and WAL mode configuration.
-- `test_vision_yolo.py`: Verifies embedding extraction arrays and cosine similarity logic using static mock images.
+주요 단위 테스트 적용 범위(Coverage)는 다음과 같다.
+- `test_validation.py`: UID 정규화 및 PIN 해싱을 검증한다.
+- `test_database*.py`: 동시 쓰기 안전성(Concurrent Write Safety) 및 WAL 모드 구성을 검증한다.
+- `test_vision_yolo.py`: 정적 모의(Mock) 이미지를 사용하여 임베딩 추출 배열과 코사인 유사도 논리를 검증한다.
 
-## System Integration Testing (Scenarios)
+## 시스템 통합 테스트 시나리오 (System Integration Testing / Scenarios)
 
-The following matrix represents the physical testing scenarios conducted on the integrated prototype.
+다음 매트릭스는 통합된 프로토타입에서 수행된 물리적 테스트 시나리오를 나타낸다.
 
-| Test ID | Scenario | Procedure | Expected Result | Actual Status |
+| 테스트 ID (Test ID) | 시나리오 (Scenario) | 절차 (Procedure) | 예상 결과 (Expected Result) | 실제 상태 (Actual Status) |
 |---|---|---|---|---|
-| INT-01 | Full Success | Present valid NFC card. Present registered face to camera. | Relay activates for 3 seconds. `SUCCESS` logged. | Pass |
-| INT-02 | Invalid Primary | Present unregistered NFC card. | Reject immediately. `FAILURE_AUTH1` logged. Camera not activated. | Pass |
-| INT-03 | Valid Primary, Invalid Face | Present valid NFC card. Present unregistered face to camera. | Reject. `FAILURE_AUTH2` logged. Relay inactive. | Pass |
-| INT-04 | Valid Primary, No Face | Present valid NFC card. Cover camera lens. | Reject after timeout. `FAILURE_TIMEOUT` logged. Relay inactive. | Pass |
-| INT-05 | Hardware Disconnect | Disconnect Arduino USB while backend running. | Backend gracefully handles `serial.SerialException` and attempts reconnection. | Pass |
+| INT-01 | 완전 성공 (Full Success) | 유효한 NFC 카드를 제시한다. 등록된 얼굴을 카메라에 제시한다. | 릴레이가 3초 동안 활성화된다. `SUCCESS`가 로깅된다. | 통과 (Pass) |
+| INT-02 | 유효하지 않은 1차 인증 (Invalid Primary) | 등록되지 않은 NFC 카드를 제시한다. | 즉시 거부한다. `FAILURE_AUTH1`이 로깅된다. 카메라가 활성화되지 않는다. | 통과 (Pass) |
+| INT-03 | 유효한 1차 인증, 유효하지 않은 얼굴 (Valid Primary, Invalid Face) | 유효한 NFC 카드를 제시한다. 등록되지 않은 얼굴을 카메라에 제시한다. | 거부한다. `FAILURE_AUTH2`가 로깅된다. 릴레이가 비활성화 상태를 유지한다. | 통과 (Pass) |
+| INT-04 | 유효한 1차 인증, 얼굴 없음 (Valid Primary, No Face) | 유효한 NFC 카드를 제시한다. 카메라 렌즈를 가린다. | 시간 초과(Timeout) 후 거부한다. `FAILURE_TIMEOUT`이 로깅된다. 릴레이가 비활성화 상태를 유지한다. | 통과 (Pass) |
+| INT-05 | 하드웨어 연결 끊김 (Hardware Disconnect) | Backend가 실행되는 동안 Arduino USB 연결을 해제한다. | Backend가 우아하게(Gracefully) `serial.SerialException`을 처리하고 재연결을 시도한다. | 통과 (Pass) |
 
-*Note: For systems deployed without physical hardware (e.g., CI/CD), a `mock_arduino.py` script simulates the serial inputs to validate backend logic without requiring the physical rig.*
+*참고: 물리적 하드웨어 없이 배포된 시스템(예: CI/CD)의 경우, `mock_arduino.py` 스크립트가 시리얼 입력을 시뮬레이션하여 물리적 장비 없이도 Backend 로직을 검증한다.*


### PR DESCRIPTION
Translated all files under `website/docs/` to Korean, including:
- Core docs (intro, executive-summary, problem-objective, architecture, authentication-flow)
- Hardware docs (hardware-overview, wiring)
- Operation docs (setup, user-guide)
- Software docs (backend, database, serial-protocol)
- Security docs (threat-model, test-plan, limitations)
- Appendix docs (development-notes, ai-assisted-workflow)

Ensured formal tone (`평어체`) and preserved technical terms in English.